### PR TITLE
Save ShortestPathSolution and AlgMetrics for each run

### DIFF
--- a/config/WAFR_experiments/trajectory_figures.yaml
+++ b/config/WAFR_experiments/trajectory_figures.yaml
@@ -21,6 +21,8 @@ domination_checker:
   num_samples_per_vertex: 10
 
 save_visualization: true
+save_solution: true
+save_metrics: true
 save_to_wandb: true
 
 hydra:

--- a/experiments/run_contact_graph_experiment.py
+++ b/experiments/run_contact_graph_experiment.py
@@ -37,8 +37,8 @@ def main(cfg: OmegaConf) -> None:
 
     # Save the configuration to the log directory
     # for some reason this folder is .../0/
-    config_save_loc = Path(full_log_dir).parent
-    config_file = config_save_loc / "config.yaml"
+    run_folder = Path(full_log_dir).parent
+    config_file = run_folder / "config.yaml"
     with open(config_file, "w") as f:
         OmegaConf.save(cfg, f)
 
@@ -125,12 +125,23 @@ def main(cfg: OmegaConf) -> None:
 
     sol: ShortestPathSolution = alg.run()
 
-    if sol is not None and cfg.save_visualization:
+    save_outputs = cfg.save_metrics or cfg.save_visualization or cfg.save_solution
+    if save_outputs:
         if "abstraction_model_generator" in cfg:
             model_name = cfg.abstraction_model_generator["_target_"].split(".")[-1]
-            output_base = f"{alg.__class__.__name__}_{model_name}_{cfg.graph_name}"
+            output_base = (
+                f"{alg.__class__.__name__}_"
+                f"{
+                    model_name}_{cfg.graph_name}"
+            )
         else:
-            output_base = f"{alg.__class__.__name__}_{cost_estimator.finger_print}_{cfg.graph_name}"
+            output_base = f"{alg.__class__.__name__}_"
+            f"{cost_estimator.finger_print}_{cfg.graph_name}"
+
+    if sol is not None and cfg.save_metrics:
+        alg.save_alg_metrics(Path(full_log_dir) / f"{output_base}metrics.json")
+
+    if sol is not None and cfg.save_visualization:
         vid_file = os.path.join(full_log_dir, f"{output_base}.mp4")
         # graphviz_file = os.path.join(full_log_dir, f"{output_base}_visited_subgraph")
         # gviz = alg._visited.graphviz()

--- a/experiments/run_contact_graph_experiment.py
+++ b/experiments/run_contact_graph_experiment.py
@@ -141,6 +141,9 @@ def main(cfg: OmegaConf) -> None:
     if sol is not None and cfg.save_metrics:
         alg.save_alg_metrics(Path(full_log_dir) / f"{output_base}metrics.json")
 
+    if sol is not None and cfg.save_solution:
+        sol.save(Path(full_log_dir) / f"{output_base}solution.pkl")
+
     if sol is not None and cfg.save_visualization:
         vid_file = os.path.join(full_log_dir, f"{output_base}.mp4")
         # graphviz_file = os.path.join(full_log_dir, f"{output_base}_visited_subgraph")

--- a/experiments/run_contact_graph_experiment.py
+++ b/experiments/run_contact_graph_experiment.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from datetime import datetime
+from pathlib import Path
 
 import hydra
 from hydra.core.hydra_config import HydraConfig
@@ -33,6 +34,13 @@ def main(cfg: OmegaConf) -> None:
     full_log_dir = hydra_config.runtime.output_dir
     with open_dict(cfg):
         cfg.log_dir = os.path.relpath(full_log_dir, get_original_cwd() + "/outputs")
+
+    # Save the configuration to the log directory
+    # for some reason this folder is .../0/
+    config_save_loc = Path(full_log_dir).parent
+    config_file = config_save_loc / "config.yaml"
+    with open(config_file, "w") as f:
+        OmegaConf.save(cfg, f)
 
     if cfg.save_to_wandb:
         wandb_config = OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True)

--- a/large_gcs/algorithms/search_algorithm.py
+++ b/large_gcs/algorithms/search_algorithm.py
@@ -2,10 +2,11 @@ import heapq as heap
 import time
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from dataclasses import dataclass, field, fields
+from dataclasses import asdict, dataclass, field, fields
 from enum import Enum
 from functools import wraps
 from math import inf
+from pathlib import Path
 from typing import DefaultDict, Dict, List, Optional
 
 import numpy as np
@@ -13,6 +14,7 @@ import plotly.graph_objects as go
 
 import wandb
 from large_gcs.graph.graph import Edge, Graph, ShortestPathSolution
+from large_gcs.utils.utils import dict_to_dataclass
 
 
 class TieBreak(Enum):
@@ -223,6 +225,36 @@ class AlgMetrics:
 
         return fig
 
+    def save(self, loc: Path) -> None:
+        """
+        Save metrics as a JSON file.
+        """
+        # Convert to dictionary and save to JSON
+        self_as_dict = asdict(self)
+        import json
+
+        with open(loc, "w") as f:
+            json.dump(self_as_dict, f, indent=4)
+
+    @classmethod
+    def load(cls, loc: Path) -> "AlgMetrics":
+        """
+        Reads metrics from a JSON file.
+        """
+
+        raise RuntimeError(
+            "NOTE! This function has not been tested. Feel\
+            free to remove this error message and run it (if it works!)"
+        )
+        # Load from JSON and convert back to dataclass
+        import json
+
+        with open(loc, "r") as f:
+            loaded_dict = json.load(f)
+
+        metrics = dict_to_dataclass(AlgMetrics, loaded_dict)
+        return metrics
+
 
 @dataclass
 class SearchNode:
@@ -309,6 +341,9 @@ class SearchAlgorithm(ABC):
                     "alg_metrics": self.alg_metrics.to_dict(),
                 }
             )
+
+    def save_alg_metrics(self, loc: Path) -> None:
+        self._alg_metrics.save(loc)
 
 
 def profile_method(method):

--- a/large_gcs/algorithms/search_algorithm.py
+++ b/large_gcs/algorithms/search_algorithm.py
@@ -241,11 +241,6 @@ class AlgMetrics:
         """
         Reads metrics from a JSON file.
         """
-
-        raise RuntimeError(
-            "NOTE! This function has not been tested. Feel\
-            free to remove this error message and run it (if it works!)"
-        )
         # Load from JSON and convert back to dataclass
         import json
 

--- a/large_gcs/graph/graph.py
+++ b/large_gcs/graph/graph.py
@@ -41,7 +41,7 @@ class ShortestPathSolution:
     # Flows along the edges (range [0, 1])
     flows: List[float]
     # Result of the optimization
-    result: MathematicalProgramResult
+    result: Optional[MathematicalProgramResult] = None
 
     def __str__(self):
         result = []
@@ -93,8 +93,8 @@ class ShortestPathSolution:
         with open(loc, "rb") as f:
             loaded_dict = pickle.load(f)
 
-        metrics = dict_to_dataclass(ShortestPathSolution, loaded_dict)
-        return metrics
+        sol = dict_to_dataclass(ShortestPathSolution, loaded_dict)
+        return sol
 
 
 @dataclass

--- a/large_gcs/graph/graph.py
+++ b/large_gcs/graph/graph.py
@@ -1,6 +1,8 @@
 import logging
+import pickle
 from copy import copy
 from dataclasses import dataclass, fields
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
 import matplotlib.patches as patches
@@ -21,6 +23,7 @@ from pydrake.all import (
 from tqdm import tqdm
 
 from large_gcs.geometry.convex_set import ConvexSet
+from large_gcs.utils.utils import dict_to_dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +73,28 @@ class ShortestPathSolution:
             )
         ambient_path += "]"
         return ambient_path
+
+    def save(self, loc: Path) -> None:
+        """
+        Save solution as a .pkl file. Note that MathematicalProgramResult cannot be
+        serialized, and hence cannot be saved to file.
+        """
+        # Convert to dictionary and save to JSON
+        self_as_dict = self.to_serializable_dict()
+        with open(loc, "wb") as f:
+            pickle.dump(self_as_dict, f)
+
+    @classmethod
+    def load(cls, loc: Path) -> "ShortestPathSolution":
+        """
+        Read a solution from a .pkl file.
+        """
+
+        with open(loc, "rb") as f:
+            loaded_dict = pickle.load(f)
+
+        metrics = dict_to_dataclass(ShortestPathSolution, loaded_dict)
+        return metrics
 
 
 @dataclass

--- a/large_gcs/utils/utils.py
+++ b/large_gcs/utils/utils.py
@@ -1,3 +1,6 @@
+import pickle
+from dataclasses import fields
+
 import numpy as np
 
 
@@ -8,3 +11,17 @@ def copy_pastable_str_from_np_array(arr):
     )
     arr_str = arr_str.replace("\n", "").replace(" ", "")
     return f"np.array({arr_str})"
+
+
+def is_pickleable(obj):
+    try:
+        pickle.dumps(obj)
+    except (pickle.PicklingError, TypeError, AttributeError):
+        return False
+    return True
+
+
+def dict_to_dataclass(klass, dikt):
+    field_names = {f.name for f in fields(klass) if f.init}
+    filtered_arg_dict = {k: v for k, v in dikt.items() if k in field_names}
+    return klass(**filtered_arg_dict)


### PR DESCRIPTION
(NB: This builds on #1 so do not merge before after we merge that in, I need to rebase this first)

Changes:
- Support saving and loading AlgMetrics as `json`
- Support saving and loading ShortestPathSolution as a pickle file
- Make `result` an optional attribute of ShortestPathSolution to support saving it to file
- Save metrics and solution based on two new flags in the config files (`save_solution` and `save_metrics`, located in the same place as `save_visualization`).
- Save the `config.yaml` together with the output data (visualization, solution, metrics, etc), as this will be useful when we want to load the data and use it for something.